### PR TITLE
fix: PR トリガー判定を厳格化し常時実行されないワークフローを除外

### DIFF
--- a/apply-settings.sh
+++ b/apply-settings.sh
@@ -278,159 +278,21 @@ decode_base64() {
 check_pr_trigger_always_runs() {
   local content="$1"
 
-  # awk で YAML を解析（必ず exit 0 で終了）
+  # スクリプトと同じディレクトリにある awk ファイルを使用
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local awk_file="${script_dir}/check-pr-trigger.awk"
+
+  # awk ファイルが存在しない場合はエラー
+  if [ ! -f "$awk_file" ]; then
+    echo "Error: $awk_file not found" >&2
+    echo "false"
+    return 1
+  fi
+
+  # 外部 awk スクリプトを使用して YAML を解析
   local result
-  result=$(echo "$content" | awk '
-    function indent(s) { match(s, /^[ \t]*/); return RLENGTH }
-    function strip_comment(s) { sub(/#.*/, "", s); return s }
-
-    BEGIN {
-      in_on=0; on_i=-1
-      in_pr=0; pr_i=-1
-      in_types=0; types_i=-1
-      found_pr=""; found_types=0
-      has_opened=0; has_reopened=0; has_sync=0
-      has_filters=0
-      always_runs=0  # どれか一つのトリガーが常時実行であれば 1
-      current_trigger=""  # 現在処理中のトリガー種別
-    }
-
-    {
-      line = strip_comment($0)
-      if (line ~ /^[ \t]*$/) next
-      i = indent(line)
-
-      # flow-style on: [pull_request, ...] の検出
-      if (line ~ /^[ \t]*on:[ \t]*\[/) {
-        if (line ~ /(^|[^a-z_])(pull_request|pull_request_target)([^a-z_]|$)/) {
-          print "true"; exit 0
-        }
-        next
-      }
-
-      # scalar での on: pull_request の検出
-      if (line ~ /^[ \t]*on:[ \t]*(pull_request|pull_request_target)[ \t]*$/) {
-        print "true"; exit 0
-      }
-
-      # on: ブロック開始判定
-      if (line ~ /^[ \t]*on:[ \t]*$/) { in_on=1; on_i=i; in_pr=0; in_types=0; next }
-
-      # on: ブロック終了判定
-      if (in_on && i <= on_i) {
-        # on: ブロック終了時に、最後のトリガーブロックを評価
-        if (in_pr) {
-          if (current_trigger == "pull_request" && has_filters) {
-            # pull_request でフィルターがある場合は常時実行ではない
-          } else if (!found_types || (has_opened && has_reopened && has_sync)) {
-            always_runs = 1
-          }
-        }
-        in_on=0; in_pr=0; in_types=0
-      }
-      if (!in_on) next
-
-      # pull_request_target キー検出（pull_request より先にチェック）
-      if (line ~ /^[ \t]*pull_request_target[ \t]*:/) {
-        # 前回のトリガーブロックの判定を行う
-        if (in_pr) {
-          if (current_trigger == "pull_request" && has_filters) {
-            # pull_request でフィルターがある場合は常時実行ではない
-          } else if (!found_types || (has_opened && has_reopened && has_sync)) {
-            always_runs = 1
-          }
-        }
-        # 新しいトリガーブロック開始：変数をリセット
-        found_pr="pull_request_target"; current_trigger="pull_request_target"
-        in_pr=1; pr_i=i; in_types=0
-        found_types=0; has_opened=0; has_reopened=0; has_sync=0; has_filters=0
-        if (line ~ /types[ \t]*:/) found_types=1
-        if (line ~ /(^|[^a-z_])opened([^a-z_]|$)/) has_opened=1
-        if (line ~ /(^|[^a-z_])reopened([^a-z_]|$)/) has_reopened=1
-        if (line ~ /(^|[^a-z_])synchronize([^a-z_]|$)/) has_sync=1
-        # pull_request_target では paths/branches フィルターは無視される
-        next
-      }
-      # pull_request キー検出（_target を除外）
-      if (line ~ /^[ \t]*pull_request[ \t]*:/ && line !~ /_target/) {
-        # 前回のトリガーブロックの判定を行う
-        if (in_pr) {
-          if (current_trigger == "pull_request" && has_filters) {
-            # pull_request でフィルターがある場合は常時実行ではない
-          } else if (!found_types || (has_opened && has_reopened && has_sync)) {
-            always_runs = 1
-          }
-        }
-        # 新しいトリガーブロック開始：変数をリセット
-        found_pr="pull_request"; current_trigger="pull_request"
-        in_pr=1; pr_i=i; in_types=0
-        found_types=0; has_opened=0; has_reopened=0; has_sync=0; has_filters=0
-        if (line ~ /types[ \t]*:/) found_types=1
-        if (line ~ /(^|[^a-z_])opened([^a-z_]|$)/) has_opened=1
-        if (line ~ /(^|[^a-z_])reopened([^a-z_]|$)/) has_reopened=1
-        if (line ~ /(^|[^a-z_])synchronize([^a-z_]|$)/) has_sync=1
-        if (line ~ /(paths|paths-ignore|branches|branches-ignore)[ \t]*:/) has_filters=1
-        next
-      }
-
-      # pull_request / pull_request_target ブロック終了
-      if (in_pr && i <= pr_i) {
-        # ブロック終了時に判定を行う
-        if (current_trigger == "pull_request" && has_filters) {
-          # pull_request でフィルターがある場合は常時実行ではない
-        } else if (!found_types || (has_opened && has_reopened && has_sync)) {
-          always_runs = 1
-        }
-        in_pr=0; in_types=0
-      }
-      if (!in_pr) next
-
-      # paths/branches フィルター判定
-      if (line ~ /^[ \t]*(paths|paths-ignore|branches|branches-ignore)[ \t]*:/) {
-        has_filters=1
-      }
-
-      # types 配列の検出と opened/reopened/synchronize 判定
-      if (line ~ /^[ \t]*types:[ \t]*\[/) {
-        found_types=1
-        if (line ~ /(^|[^a-z_])opened([^a-z_]|$)/) has_opened=1
-        if (line ~ /(^|[^a-z_])reopened([^a-z_]|$)/) has_reopened=1
-        if (line ~ /(^|[^a-z_])synchronize([^a-z_]|$)/) has_sync=1
-        next
-      }
-      if (line ~ /^[ \t]*types:[ \t]*$/) {
-        found_types=1; in_types=1; types_i=i; next
-      }
-      if (in_types) {
-        if (i <= types_i) { in_types=0 }
-        else {
-          if (line ~ /^[ \t]*-[ \t]*opened[ \t]*$/) has_opened=1
-          if (line ~ /^[ \t]*-[ \t]*reopened[ \t]*$/) has_reopened=1
-          if (line ~ /^[ \t]*-[ \t]*synchronize[ \t]*$/) has_sync=1
-        }
-      }
-    }
-
-    END {
-      # PR トリガーが見つからなかった場合
-      if (found_pr == "") { print "false"; exit 0 }
-
-      # 最後のトリガーブロックが終了していない場合（ファイル終端）の判定
-      if (in_pr) {
-        if (current_trigger == "pull_request" && has_filters) {
-          # pull_request でフィルターがある場合は常時実行ではない
-        } else if (!found_types || (has_opened && has_reopened && has_sync)) {
-          always_runs = 1
-        }
-      }
-
-      # どれか一つのトリガーが常時実行であれば true
-      if (always_runs) { print "true"; exit 0 }
-
-      print "false"
-      exit 0
-    }
-  ')
+  result=$(echo "$content" | awk -f "$awk_file")
 
   echo "$result"
 }

--- a/check-pr-trigger.awk
+++ b/check-pr-trigger.awk
@@ -1,0 +1,153 @@
+# PR トリガーが常時実行されるかチェックする awk スクリプト
+# GitHub Actions の pull_request/pull_request_target トリガーを解析し、
+# PR のライフサイクル全体（opened, reopened, synchronize）で実行されるか判定
+
+function indent(s) { match(s, /^[ \t]*/); return RLENGTH }
+function strip_comment(s) { sub(/#.*/, "", s); return s }
+
+BEGIN {
+  in_on=0; on_i=-1
+  in_pr=0; pr_i=-1
+  in_types=0; types_i=-1
+  found_pr=""; found_types=0
+  has_opened=0; has_reopened=0; has_sync=0
+  has_filters=0
+  always_runs=0  # どれか一つのトリガーが常時実行であれば 1
+  current_trigger=""  # 現在処理中のトリガー種別
+}
+
+{
+  line = strip_comment($0)
+  if (line ~ /^[ \t]*$/) next
+  i = indent(line)
+
+  # flow-style on: [pull_request, ...] の検出
+  if (line ~ /^[ \t]*on:[ \t]*\[/) {
+    if (line ~ /(^|[^a-z_])(pull_request|pull_request_target)([^a-z_]|$)/) {
+      print "true"; exit 0
+    }
+    next
+  }
+
+  # scalar での on: pull_request の検出
+  if (line ~ /^[ \t]*on:[ \t]*(pull_request|pull_request_target)[ \t]*$/) {
+    print "true"; exit 0
+  }
+
+  # on: ブロック開始判定
+  if (line ~ /^[ \t]*on:[ \t]*$/) { in_on=1; on_i=i; in_pr=0; in_types=0; next }
+
+  # on: ブロック終了判定
+  if (in_on && i <= on_i) {
+    # on: ブロック終了時に、最後のトリガーブロックを評価
+    if (in_pr) {
+      if (current_trigger == "pull_request" && has_filters) {
+        # pull_request でフィルターがある場合は常時実行ではない
+      } else if (!found_types || (has_opened && has_reopened && has_sync)) {
+        always_runs = 1
+      }
+    }
+    in_on=0; in_pr=0; in_types=0
+  }
+  if (!in_on) next
+
+  # pull_request_target キー検出（pull_request より先にチェック）
+  if (line ~ /^[ \t]*pull_request_target[ \t]*:/) {
+    # 前回のトリガーブロックの判定を行う
+    if (in_pr) {
+      if (current_trigger == "pull_request" && has_filters) {
+        # pull_request でフィルターがある場合は常時実行ではない
+      } else if (!found_types || (has_opened && has_reopened && has_sync)) {
+        always_runs = 1
+      }
+    }
+    # 新しいトリガーブロック開始：変数をリセット
+    found_pr="pull_request_target"; current_trigger="pull_request_target"
+    in_pr=1; pr_i=i; in_types=0
+    found_types=0; has_opened=0; has_reopened=0; has_sync=0; has_filters=0
+    if (line ~ /types[ \t]*:/) found_types=1
+    if (line ~ /(^|[^a-z_])opened([^a-z_]|$)/) has_opened=1
+    if (line ~ /(^|[^a-z_])reopened([^a-z_]|$)/) has_reopened=1
+    if (line ~ /(^|[^a-z_])synchronize([^a-z_]|$)/) has_sync=1
+    # pull_request_target では paths/branches フィルターは無視される
+    next
+  }
+  # pull_request キー検出（_target を除外）
+  if (line ~ /^[ \t]*pull_request[ \t]*:/ && line !~ /_target/) {
+    # 前回のトリガーブロックの判定を行う
+    if (in_pr) {
+      if (current_trigger == "pull_request" && has_filters) {
+        # pull_request でフィルターがある場合は常時実行ではない
+      } else if (!found_types || (has_opened && has_reopened && has_sync)) {
+        always_runs = 1
+      }
+    }
+    # 新しいトリガーブロック開始：変数をリセット
+    found_pr="pull_request"; current_trigger="pull_request"
+    in_pr=1; pr_i=i; in_types=0
+    found_types=0; has_opened=0; has_reopened=0; has_sync=0; has_filters=0
+    if (line ~ /types[ \t]*:/) found_types=1
+    if (line ~ /(^|[^a-z_])opened([^a-z_]|$)/) has_opened=1
+    if (line ~ /(^|[^a-z_])reopened([^a-z_]|$)/) has_reopened=1
+    if (line ~ /(^|[^a-z_])synchronize([^a-z_]|$)/) has_sync=1
+    if (line ~ /(paths|paths-ignore|branches|branches-ignore)[ \t]*:/) has_filters=1
+    next
+  }
+
+  # pull_request / pull_request_target ブロック終了
+  if (in_pr && i <= pr_i) {
+    # ブロック終了時に判定を行う
+    if (current_trigger == "pull_request" && has_filters) {
+      # pull_request でフィルターがある場合は常時実行ではない
+    } else if (!found_types || (has_opened && has_reopened && has_sync)) {
+      always_runs = 1
+    }
+    in_pr=0; in_types=0
+  }
+  if (!in_pr) next
+
+  # paths/branches フィルター判定
+  if (line ~ /^[ \t]*(paths|paths-ignore|branches|branches-ignore)[ \t]*:/) {
+    has_filters=1
+  }
+
+  # types 配列の検出と opened/reopened/synchronize 判定
+  if (line ~ /^[ \t]*types:[ \t]*\[/) {
+    found_types=1
+    if (line ~ /(^|[^a-z_])opened([^a-z_]|$)/) has_opened=1
+    if (line ~ /(^|[^a-z_])reopened([^a-z_]|$)/) has_reopened=1
+    if (line ~ /(^|[^a-z_])synchronize([^a-z_]|$)/) has_sync=1
+    next
+  }
+  if (line ~ /^[ \t]*types:[ \t]*$/) {
+    found_types=1; in_types=1; types_i=i; next
+  }
+  if (in_types) {
+    if (i <= types_i) { in_types=0 }
+    else {
+      if (line ~ /^[ \t]*-[ \t]*opened[ \t]*$/) has_opened=1
+      if (line ~ /^[ \t]*-[ \t]*reopened[ \t]*$/) has_reopened=1
+      if (line ~ /^[ \t]*-[ \t]*synchronize[ \t]*$/) has_sync=1
+    }
+  }
+}
+
+END {
+  # PR トリガーが見つからなかった場合
+  if (found_pr == "") { print "false"; exit 0 }
+
+  # 最後のトリガーブロックが終了していない場合（ファイル終端）の判定
+  if (in_pr) {
+    if (current_trigger == "pull_request" && has_filters) {
+      # pull_request でフィルターがある場合は常時実行ではない
+    } else if (!found_types || (has_opened && has_reopened && has_sync)) {
+      always_runs = 1
+    }
+  }
+
+  # どれか一つのトリガーが常時実行であれば true
+  if (always_runs) { print "true"; exit 0 }
+
+  print "false"
+  exit 0
+}


### PR DESCRIPTION
## Summary

Issue #9 で報告された「必ず動作するわけではない pull_request トリガーが必須設定になっている」問題を修正しました。

## 変更内容

### 問題の原因

従来の実装では、単純な正規表現で `pull_request:` を含むすべてのワークフローを検出していました。そのため、以下のような「条件付きトリガー」も必須ステータスチェックに含まれていました。

```yaml
on:
  pull_request_target:
    types: [review_requested]  # PR push では実行されない
```

### 修正内容

新規関数 `check_pr_trigger_always_runs()` を追加し、以下の3段階で判定します：

1. **PR トリガーの存在確認**: `pull_request:` または `pull_request_target:` の検出
2. **types フィールドの有無**: `types:` がない場合は常時実行と判定
3. **types の内容確認**: `opened`, `reopened`, `synchronize` の3つすべてを含む場合のみ常時実行と判定

### 技術的な実装

**awk による部分的 YAML 解析**を使用し、以下の点を考慮：

- **`on:` ブロック内に限定**: インデントベースで `on:` ブロック内のみを解析（`jobs` などでの誤判定を防止）
- **フィルターの検出**: `paths`, `branches` フィルターを正しく処理
  - `pull_request`: フィルターがある場合は除外（常時実行ではない）
  - `pull_request_target`: フィルターは無視される（GitHub Actions 仕様）
- **エラーハンドリング**: `set -euo pipefail` 環境でも安全に動作（awk は必ず exit 0）
- **正確な types 判定**: `opened`, `reopened`, `synchronize` の3つすべてが必要（GitHub Actions の最新仕様に準拠）

### 修正箇所

**第1コミット（初期実装）**:
- **新規追加**: `check_pr_trigger_always_runs()` 関数（行275-378）
- **修正**: `check_has_pr_workflow()` - 正規表現判定を新関数呼び出しに置き換え（行408）
- **修正**: `detect_status_checks()` - 正規表現判定を新関数呼び出しに置き換え、不要な判定ロジックを削除（行705-710）

**第2コミット（pull_request_target フィルター処理の修正）**:
- GitHub Actions の仕様では、`pull_request_target` は `paths` と `branches` フィルターを無視します
- `found_pr` を boolean から string (`"pull_request"` | `"pull_request_target"`) に変更
- `pull_request` と `pull_request_target` の検出ロジックを分離（`pull_request_target` を先にチェック）
- END ブロックで `pull_request` の場合のみフィルターをチェックするように修正

## テスト結果

### 期待される動作

#### 常時実行として検出される（true）

- ✅ `types:` 未指定 → デフォルトで `[opened, reopened, synchronize]`
- ✅ `types: [opened, reopened, synchronize]` → 3つすべてを含む
- ✅ `pull_request_target` with `paths` フィルター → フィルターは無視される

#### 除外される（false）

- ✅ `types: [review_requested]` → Issue #9 の実例、`synchronize` を含まない
- ✅ `types: [labeled]` → `opened`, `reopened`, `synchronize` を含まない
- ✅ `types: [opened]` のみ → `reopened`, `synchronize` が欠けている
- ✅ `pull_request` with `paths` フィルター → 常時実行ではない

### ローカルテスト

```bash
# 構文チェック
bash -n apply-settings.sh  # OK

# dry-run テスト
./apply-settings.sh --dry-run  # 正常動作確認済み

# pull_request_target with paths の動作確認
./test-issue7-fix.sh  # すべてのテストケースで PASS
```

## レビュー

### Codex CLI レビュー

- ✅ awk ロジックの正当性を確認
- ✅ `on:` ブロック限定の必要性を指摘
- ✅ `paths`/`branches` フィルターの考慮を指摘
- ✅ エラーハンドリング（`set -euo pipefail`）を指摘
- ✅ `pull_request_target` のフィルター処理について指摘（Issue #7）

### Gemini CLI レビュー

- ✅ GitHub Actions の最新仕様（2026年時点）を確認
- ✅ **重要**: `opened`, `reopened`, `synchronize` の3つすべてが必要と確認
- ✅ `types` 未指定時のデフォルト動作を確認
- ✅ `pull_request` と `pull_request_target` の違いを明確化
- ✅ `pull_request_target` は `paths`/`branches` フィルターを無視することを確認

## Test Plan

- [ ] `gh pr checks <PR_NUMBER> --watch` で GitHub Actions CI を待ち、成功を確認
- [ ] book000/update-softwares の `reply-to-review.yml` が正しく除外されることを確認
- [ ] 実際のリポジトリで dry-run を実行し、期待通り動作することを確認

## 関連 Issue

- Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)