### PR TITLE
fix: フォークからの PR で pr-preview のコメント投稿が失敗する問題を修正

### DIFF
--- a/.github/workflows/pr-preview-comment.yml
+++ b/.github/workflows/pr-preview-comment.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     # workflow_run は完了を待つため、失敗した場合もコメントを投稿
     if: >
-      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'pull_request_target') &&
       github.event.workflow_run.conclusion != 'cancelled'
     permissions:
       actions: read
@@ -19,6 +20,7 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
@@ -57,10 +59,20 @@ jobs:
       - name: Read results
         id: results
         run: |
+          set -euo pipefail
+
           if [ -f pr-preview-results/summary.txt ]; then
             {
               echo 'summary<<EOF'
               cat pr-preview-results/summary.txt
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'summary<<EOF'
+              echo '## 結果の取得に失敗しました'
+              echo ''
+              echo 'dry-run の結果が artifact に保存されていません。'
               echo 'EOF'
             } >> "$GITHUB_OUTPUT"
           fi
@@ -69,6 +81,12 @@ jobs:
             {
               echo 'details<<EOF'
               cat pr-preview-results/details.txt
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo 'details<<EOF'
+              echo 'ログがありません。'
               echo 'EOF'
             } >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -41,21 +41,29 @@ jobs:
         run: |
           chmod +x ./apply-settings.sh
 
-          # フォークからの PR の場合、PAT が空になる
+          # PAT が空の場合のエラーハンドリング
           if [ -z "$GH_TOKEN" ]; then
-            echo "## フォークからの PR では dry-run を実行できません" > summary.txt
-            echo "" >> summary.txt
-            echo "セキュリティ上の理由から、フォークからの PR では他のリポジトリの情報にアクセスできません。" >> summary.txt
-            echo "" >> summary.txt
-            echo "### 実行する方法" >> summary.txt
-            echo "" >> summary.txt
-            echo "write 権限を持つコラボレーターが以下の手順で実行を承認できます：" >> summary.txt
-            echo "" >> summary.txt
-            echo "1. GitHub Actions の [Workflows](https://github.com/\${{ github.repository }}/actions/workflows/pr-preview.yml) を開く" >> summary.txt
-            echo "2. 実行待ちのワークフローを確認" >> summary.txt
-            echo "3. PR のコード内容を確認した上で、「Review deployments」をクリックして承認" >> summary.txt
-            echo "" >> summary.txt
-            echo "**注意**: 承認すると、PR のコード（apply-settings.sh を含む）が実行されます。" >> summary.txt
+            if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+              # フォークからの PR の場合
+              echo "## フォークからの PR では dry-run を実行できません" > summary.txt
+              echo "" >> summary.txt
+              echo "セキュリティ上の理由から、フォークからの PR では他のリポジトリの情報にアクセスできません。" >> summary.txt
+              echo "" >> summary.txt
+              echo "### 実行する方法" >> summary.txt
+              echo "" >> summary.txt
+              echo "write 権限を持つコラボレーターが以下の手順で実行を承認できます：" >> summary.txt
+              echo "" >> summary.txt
+              echo "1. GitHub Actions の [Workflows](https://github.com/$GITHUB_REPOSITORY/actions/workflows/pr-preview.yml) を開く" >> summary.txt
+              echo "2. 実行待ちのワークフローを確認" >> summary.txt
+              echo "3. PR のコード内容を確認した上で、「Review deployments」をクリックして承認" >> summary.txt
+              echo "" >> summary.txt
+              echo "**注意**: 承認すると、PR のコード（apply-settings.sh を含む）が実行されます。" >> summary.txt
+            else
+              # 同一リポジトリからの PR の場合
+              echo "## PERSONAL_ACCESS_TOKEN が設定されていません" > summary.txt
+              echo "" >> summary.txt
+              echo "dry-run を実行するには、Repository Secrets に PERSONAL_ACCESS_TOKEN を設定してください。" >> summary.txt
+            fi
             echo "" > details.txt
             exit 0
           fi
@@ -72,6 +80,11 @@ jobs:
             echo "" >> summary.txt
             echo "終了コード: $exit_code" >> summary.txt
           fi
+
+      - name: Ensure result files exist
+        if: always()
+        run: |
+          touch summary.txt details.txt
 
       - name: Upload results as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

フォークリポジトリからの PR で `pr-preview.yml` のコメント投稿が失敗する問題を修正し、Environment による承認フローを追加しました。

## 問題

GitHub Actions では、セキュリティ上の理由から、フォークからの PR に対して `pull_request` イベントで実行されるワークフローは、書き込み権限が read-only に降格されます。そのため、PR にコメントを投稿できませんでした。

## 解決策

**2 段階ワークフロー + Environment 承認フロー**を採用しました。

### 1. 2 段階ワークフロー（コメント投稿の修正）

1. **`pr-preview.yml` (pull_request / pull_request_target イベント)**
   - dry-run を実行し、結果を artifact として保存
   - コメント投稿は行わない

2. **`pr-preview-comment.yml` (workflow_run イベント)**
   - ワークフロー 1 が完了したら自動実行
   - artifact から dry-run 結果を取得
   - `GITHUB_TOKEN` を使用して PR にコメントを投稿
   - base リポジトリのコンテキストで実行されるため、write 権限を持つ

### 2. Environment 承認フロー（フォークからの PR での実行）

フォークからの PR でも、write 権限を持つコラボレーターが Environment で承認すれば dry-run を実行できます。

**承認手順:**
1. GitHub Actions の [Workflows](https://github.com/book000/sync-repo-settings/actions/workflows/pr-preview.yml) を開く
2. 実行待ちのワークフロー（黄色のステータス）を確認
3. PR のコード内容を確認した上で、「Review deployments」ボタンをクリックして承認
4. 承認後、自動的に dry-run が実行されます

**注意**: 承認すると、PR のコード（`apply-settings.sh` を含む）が実行されます。コードを確認してから承認してください。

## Environment の設定（初回のみ）

このワークフローを使用するには、`pr-preview` Environment の設定が必要です。

### 設定手順

1. **Environment の作成**
   - [Settings → Environments](https://github.com/book000/sync-repo-settings/settings/environments) を開く
   - 「New environment」をクリック
   - Name に `pr-preview` を入力して「Configure environment」をクリック

2. **Protection Rules の設定**
   - 「Required reviewers」にチェックを入れる
   - write 権限を持つユーザー（例: book000, akubiusa）を追加
   - 「Save protection rules」をクリック

3. **完了**
   - これで、フォークからの PR で `pull_request_target` が実行される際、設定した reviewers に承認リクエストが届きます

## 動作フロー

### 同一リポジトリからの PR
- `pull_request` イベントで自動的に dry-run を実行
- 承認不要

### フォークからの PR（承認なし）
- `pull_request` イベントでトリガー
- PAT が空のため、エラーメッセージを表示
- 「GitHub Actions で承認してください」と案内

### フォークからの PR（承認あり）
- `pull_request_target` イベントでトリガー
- Environment `pr-preview` で承認待ち状態になる
- コラボレーターが GitHub Actions の UI で承認
- 承認後、**PR のコード全体（apply-settings.sh を含む）**をチェックアウト
- dry-run を実行

## 主な変更点

### `.github/workflows/pr-preview.yml`
- `pull_request_target` イベントを追加
- Environment `pr-preview` による手動承認フローを実装
- 承認後は PR のコード全体を実行
- フォークからの PR（承認なし）の場合、Environment 承認の手順を案内
- `if: always()` を追加して、dry-run 失敗時も artifact をアップロード
- エラーハンドリングを強化
- **品質改善**:
  - GitHub repository 変数の展開を修正（`$GITHUB_REPOSITORY` を使用）
  - PAT が空の場合のエラーメッセージをイベントタイプで分岐
  - artifact アップロード前に結果ファイルの存在を保証

### `.github/workflows/pr-preview-comment.yml` (新規作成)
- `workflow_run` イベントで PR Preview ワークフローの完了を検知
- artifact から結果を取得
- `actions: read` 権限を追加（artifact ダウンロードに必須）
- PR 番号ファイル読み込み時のエラーハンドリングを追加（数値チェック、`set -euo pipefail`）
- PR にコメントを投稿
- **品質改善**:
  - `pull_request_target` イベントの条件を追加
  - Read results ステップに `set -euo pipefail` を追加
  - summary/details が存在しない場合のデフォルトメッセージを追加
  - artifact ダウンロード失敗時に `continue-on-error` を追加

## セキュリティ上の利点

- **PAT の露出を制限**: フォークからの PR（承認なし）では PAT にアクセスできない
- **信頼されたコードのみ実行**: Environment 承認により、コラボレーターが内容を確認してから実行
- **承認履歴が残る**: GitHub の Environment 機能により、承認履歴が明確に記録される
- **最小権限の原則**: 各ワークフローは必要な権限のみを持つ
- **2 段階ワークフローによる分離**: Secrets の分離とセキュリティを向上

## メリット

- **フォークからの PR でもテスト可能**: 承認があれば、apply-settings.sh の変更もテストできる
- **セキュリティと利便性のバランス**: Environment 承認で安全性を確保しつつ、柔軟にテスト可能
- **承認履歴が明確**: GitHub の標準機能により、誰がいつ承認したかが記録される
- **同一リポジトリからの PR は自動実行**: 既存の動作を維持
- **堅牢なエラーハンドリング**: 各種エラーケースに対応し、適切なメッセージを表示

## テスト計画

- [x] ローカルでの構文チェック
- [x] コードレビューによる問題検出と修正
- [x] GitHub Copilot レビューへの対応
- [ ] Environment の設定
- [ ] 同一リポジトリからの PR テスト
- [ ] フォークからの PR テスト（承認なし - エラーメッセージ表示）
- [ ] フォークからの PR テスト（承認あり - dry-run 実行）

## 参考資料

- [GitHub Actions: workflow_run event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)
- [GitHub Actions: pull_request_target event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
- [GitHub Actions: Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)
- [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)