### PR TITLE
fix: Environment 承認依頼コメントを承認前に投稿するよう修正

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -6,16 +6,13 @@ on:
       - master
 
 jobs:
-  preview:
+  post-approval-request:
     runs-on: ubuntu-latest
-    # pull_request_target（フォーク）の場合は Environment で承認が必要
-    environment: ${{ github.event_name == 'pull_request_target' && 'pr-preview' || null }}
+    if: github.event_name == 'pull_request_target'
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - name: Post approval request comment
-        if: github.event_name == 'pull_request_target'
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -26,6 +23,14 @@ jobs:
 
             [Actions run を確認して承認してください](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
 
+  preview:
+    runs-on: ubuntu-latest
+    needs: post-approval-request
+    # pull_request_target（フォーク）の場合は Environment で承認が必要
+    environment: ${{ github.event_name == 'pull_request_target' && 'pr-preview' || null }}
+    permissions:
+      contents: read
+    steps:
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 問題

PR #17 で実装した Environment 承認依頼コメント機能ですが、`environment` が job レベルで設定されているため、コメント投稿ステップを含むすべてのステップが Environment 承認後に実行されていました。

## 解決策

承認依頼コメントを投稿する job を別に作成し、Environment 承認の前に実行されるようにしました。

### 変更内容

1. **新しい job `post-approval-request` を追加**
   - Environment 不要
   - `pull_request_target` イベントの場合のみ実行
   - 承認依頼コメントを投稿

2. **`preview` job を修正**
   - `needs: post-approval-request` を追加
   - コメント投稿後に実行される
   - Environment 承認が必要

これにより、承認依頼コメントが Environment 承認の前に投稿されるようになります。

## テスト計画

- [ ] 新しい PR を作成して、承認依頼コメントが即座に投稿されることを確認
- [ ] Environment 承認後、dry-run が実行されることを確認
- [ ] dry-run 結果が PR にコメントされることを確認