### PR TITLE
feat: allow merge commit for pixivts (release flow)

### DIFF
--- a/config.json
+++ b/config.json
@@ -123,6 +123,19 @@
       "settings": {
         "rulesets": { "mode": "skip" }
       }
+    },
+    {
+      "name": "pixivts: allow merge commit (release flow)",
+      "filter": {
+        "name_pattern": "^pixivts$"
+      },
+      "settings": {
+        "repo_settings": {
+          "values": {
+            "allow_merge_commit": true
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## 概要

`pixivts` に merge commit を許可する例外ルールを追加します。

## 背景

`pixivts` のリリースパイプラインは `develop`（beta）→ `master`（stable）ブランチフローを採用しています。`develop→master` の Release PR は、semantic-release が全コミット履歴を辿って正しい stable バージョンを算出・publish できるよう、**merge commit（`--no-ff`）でマージする必要があります**。

`defaults` ブロックでは全リポジトリに `allow_merge_commit: false` が設定されています。例外ルールがないと、毎日 09:00 JST の sync で pixivts のリポジトリ設定が上書きされ、`master` ruleset が `allowed_merge_methods: ["merge"]` を要求しているにもかかわらず merge commit が無効化され、**Release PR がマージ不能（デッドロック）になります**。

## 変更内容

`rules[]` の末尾に、リポジトリ名が `pixivts` にマッチするものだけを対象に `allow_merge_commit: true` を設定するルールを追加します。他の設定は defaults のままです。

```json
{
  "name": "pixivts: allow merge commit (release flow)",
  "filter": { "name_pattern": "^pixivts$" },
  "settings": {
    "repo_settings": {
      "values": { "allow_merge_commit": true }
    }
  }
}
```

なお `name_pattern` はリポジトリ名のみにマッチし、オーナーは考慮されません。現時点で `tomacheese/pixivts` は存在しませんが、将来作成された場合は同ルールが適用される点に留意してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)